### PR TITLE
Fix corruption of WAV on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /dep
 plugin.dylib
+/.vscode
+plugin.dll

--- a/src/Recorder.cpp
+++ b/src/Recorder.cpp
@@ -2,274 +2,280 @@
 #include "dsp/digital.hpp"
 #include "wavwriter.hpp"
 
-#include <vector>
 #include <iostream>
+#include <vector>
 
 std::vector<uint8_t> to_bytes(SampleFmt format, std::vector<float> buffer) {
-    std::vector<uint8_t> byte_buffer;
-    for (float x : buffer) {
-        // Note: Audio output from Eurorack devices is +-12V
-        if (format == SampleFmt::PCM_U8) {
-            // Range will be from 0 to 255
-            uint8_t sample = 127 * (x / 12 + 1);
-            byte_buffer.push_back(sample);
-        } else if (format == SampleFmt::PCM_S16) {
-            // Range will be from -32766 to 32766
-            int16_t sample = 32766 * (x / 12);
-            // Pretend the 16bit integer is actually just two 8 bit bytes
-            uint8_t const* casted = reinterpret_cast<uint8_t const *>(&sample);
-            byte_buffer.push_back(casted[0]);
-            byte_buffer.push_back(casted[1]);
-        } else if (format == SampleFmt::FLOAT_32) {
-            // Wav files are expecting floats between -1 and 1.
-            float sample = x / 12;
-            // Pretend the 32bit float is actually just four 8 bit bytes
-            uint8_t const* casted = reinterpret_cast<uint8_t const *>(&sample);
-            byte_buffer.push_back(casted[0]);
-            byte_buffer.push_back(casted[1]);
-            byte_buffer.push_back(casted[2]);
-            byte_buffer.push_back(casted[3]);
-        } else {
-            assert(not "an expected format");
-        }
+  std::vector<uint8_t> byte_buffer;
+  for (float x : buffer) {
+    // Note: Audio output from Eurorack devices is +-12V
+    if (format == SampleFmt::PCM_U8) {
+      // Range will be from 0 to 255
+      uint8_t sample = 127 * (x / 12 + 1);
+      byte_buffer.push_back(sample);
+    } else if (format == SampleFmt::PCM_S16) {
+      // Range will be from -32766 to 32766
+      int16_t sample = 32766 * (x / 12);
+      // Pretend the 16bit integer is actually just two 8 bit bytes
+      uint8_t const *casted = reinterpret_cast<uint8_t const *>(&sample);
+      byte_buffer.push_back(casted[0]);
+      byte_buffer.push_back(casted[1]);
+    } else if (format == SampleFmt::FLOAT_32) {
+      // Wav files are expecting floats between -1 and 1.
+      float sample = x / 12;
+      // Pretend the 32bit float is actually just four 8 bit bytes
+      uint8_t const *casted = reinterpret_cast<uint8_t const *>(&sample);
+      byte_buffer.push_back(casted[0]);
+      byte_buffer.push_back(casted[1]);
+      byte_buffer.push_back(casted[2]);
+      byte_buffer.push_back(casted[3]);
+    } else {
+      assert(not"an expected format");
     }
-    return byte_buffer;
+  }
+
+  return byte_buffer;
 }
 
 // Returns true if the filename exists
-bool file_exists(const std::string& name) {
-    if (FILE *file = fopen(name.c_str(), "r")) {
-        fclose(file);
-        return true;
-    } else {
-        return false;
-    }
+bool file_exists(const std::string &name) {
+  if (FILE *file = fopen(name.c_str(), "r")) {
+    fclose(file);
+    return true;
+  } else {
+    return false;
+  }
 }
 
 struct Recorder : Module {
-    enum ParamIds {
-        RECORD_BUTTON = 0,
-        MONO_STEREO = 1,
-        NUM_PARAMS = 2,
-    };
+  enum ParamIds {
+    RECORD_BUTTON = 0,
+    MONO_STEREO = 1,
+    NUM_PARAMS = 2,
+  };
 
-    enum OutputIds {
-        NUM_OUTPUTS = 0,
-    };
+  enum OutputIds {
+    NUM_OUTPUTS = 0,
+  };
 
-    // A status light for the record butotn
-    enum LightIds {
-        NUM_LIGHTS = 1,
-    };
+  // A status light for the record butotn
+  enum LightIds {
+    NUM_LIGHTS = 1,
+  };
 
-    // 2 inputs, for left and right channels
-    enum InputIds {
-        LEFT_INPUT = 0,
-        RIGHT_INPUT = 1,
-        NUM_INPUTS = 2,
-    };
+  // 2 inputs, for left and right channels
+  enum InputIds {
+    LEFT_INPUT = 0,
+    RIGHT_INPUT = 1,
+    NUM_INPUTS = 2,
+  };
 
-    size_t num_samples = 0;
-    std::vector<float> buffer; // keeps track of the currently written samples
-    bool recording = false;
-    SampleFmt format = SampleFmt::FLOAT_32;
-    int num_channels = 1;
+  size_t num_samples = 0;
+  std::vector<float> buffer; // keeps track of the currently written samples
+  bool recording = false;
+  SampleFmt format = SampleFmt::FLOAT_32;
+  int num_channels = 1;
 
-    Recorder() : Module(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS) {}
-    void step() override;
+  Recorder() : Module(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS) {}
+  void step() override;
 
-    float getSeconds() {
-        return num_samples / engineGetSampleRate();
-    }
+  float getSeconds() { return num_samples / engineGetSampleRate(); }
 };
 
 void Recorder::step() {
-    bool button_on = params[Recorder::RECORD_BUTTON].value;
-    bool is_stereo = params[Recorder::MONO_STEREO].value;
+  bool button_on = params[Recorder::RECORD_BUTTON].value;
+  bool is_stereo = params[Recorder::MONO_STEREO].value;
 
-    if (not recording) {
-        num_channels = is_stereo ? 2 : 1;
+  if (not recording) {
+    num_channels = is_stereo ? 2 : 1;
+  }
+
+  // Went from not recording state to recording state
+  if (not recording and button_on) {
+    printf("Recording %d channels %f, %s\n", num_channels,
+           engineGetSampleRate(), toString(format));
+    buffer.clear();
+    // Push an initial empty sample to make sure the file doesn't start silent
+    // (otherwise, some programs interpret the WAV as corrupt or completly
+    // empty).
+    buffer.push_back(0.1);
+    buffer.push_back(0.1);
+    num_samples = num_channels == 1 ? 2 : 1;
+  }
+
+  if (recording and not button_on) {
+    int i = 0;
+    std::string filename = "recording0.wav";
+
+    do {
+      i++;
+      filename = "recording" + std::to_string(i) + ".wav";
+    } while (file_exists(filename));
+
+    std::vector<uint8_t> byte_buffer = to_bytes(format, buffer);
+    writewav(&byte_buffer[0], format, num_channels, num_samples,
+             engineGetSampleRate(), filename.c_str());
+    printf("Wrote %s\n", filename.c_str());
+  }
+
+  if (recording) {
+    // Note: While this buffer always has floats, the actual conversion is done
+    // at write time
+    if (num_channels == 1) {
+      buffer.push_back(inputs[Recorder::LEFT_INPUT].value);
+    } else {
+      // When stereo, the samples are interleaved.
+      buffer.push_back(inputs[Recorder::LEFT_INPUT].value);
+      buffer.push_back(inputs[Recorder::RIGHT_INPUT].value);
     }
+    num_samples += 1;
+  }
 
-    // Went from not recording state to recording state
-    if (not recording and button_on) {
-        printf("Recording %d channels %f, %s\n", num_channels, engineGetSampleRate(), toString(format));
-        buffer.clear();
-        // Push an initial empty sample to make sure the file doesn't start silent
-        // (otherwise, some programs interpret the WAV as corrupt or completly empty).
-        buffer.push_back(0.1);
-        buffer.push_back(0.1);
-        num_samples = num_channels == 1 ? 2 : 1;
-    }
-
-    if (recording and not button_on) {
-        int i = 0;
-        std::string filename = "recording0.wav";
-
-        do {
-            i++;
-            filename = "recording" + std::to_string(i) + ".wav";
-        }
-        while (file_exists(filename));
-        std::vector<uint8_t> byte_buffer = to_bytes(format, buffer);
-        writewav(&byte_buffer[0], format, num_channels, num_samples, engineGetSampleRate(), filename.c_str());
-        printf("Wrote %s\n", filename.c_str());
-    }
-
-    if (recording) {
-        // Note: While this buffer always has floats, the actual conversion is done at write time
-        if (num_channels == 1) {
-            buffer.push_back(inputs[Recorder::LEFT_INPUT].value);
-        } else {
-            // When stereo, the samples are interleaved.
-            buffer.push_back(inputs[Recorder::LEFT_INPUT].value);
-            buffer.push_back(inputs[Recorder::RIGHT_INPUT].value);
-        }
-        num_samples += 1;
-    }
-
-    recording = button_on;
+  recording = button_on;
 }
 
 struct RecordButton : SVGSwitch, ToggleSwitch {
-    RecordButton() {
-        addFrame(SVG::load(assetPlugin(plugin, "res/DarkButton.svg")));
-        addFrame(SVG::load(assetPlugin(plugin, "res/LightButton.svg")));
-    }
+  RecordButton() {
+    addFrame(SVG::load(assetPlugin(plugin, "res/DarkButton.svg")));
+    addFrame(SVG::load(assetPlugin(plugin, "res/LightButton.svg")));
+  }
 };
 
 struct FormatItem : MenuItem {
-    SampleFmt format;
-    Recorder *recorder;
-    FormatItem(SampleFmt format, Recorder *recorder) {
-        this->format = format;
-        this->text = toString(format);
-        this->recorder = recorder;
-        this->rightText = CHECKMARK(format == recorder->format);
-    }
+  SampleFmt format;
+  Recorder *recorder;
+  FormatItem(SampleFmt format, Recorder *recorder) {
+    this->format = format;
+    this->text = toString(format);
+    this->recorder = recorder;
+    this->rightText = CHECKMARK(format == recorder->format);
+  }
 
-    // on click, set the Recorder to use the selected format.
-    void onAction(EventAction &e) override {
-        recorder->format = this->format;
-    }
+  // on click, set the Recorder to use the selected format.
+  void onAction(EventAction &e) override { recorder->format = this->format; }
 };
 
 struct RecordingDisplay : LedDisplay {
-    char msg[8] = {0};
-    bool recording = false;
+  char msg[8] = {0};
+  bool recording = false;
 
-    LedDisplayChoice *timerText = nullptr;
-    LedDisplaySeparator *separator = nullptr;
-    LedDisplayChoice *formatChoice = nullptr;
-    Recorder *recorder;
+  LedDisplayChoice *timerText = nullptr;
+  LedDisplaySeparator *separator = nullptr;
+  LedDisplayChoice *formatChoice = nullptr;
+  Recorder *recorder;
 
-    RecordingDisplay() {
-        box.size = Vec(35, 44);
-        Vec pos = Vec(0, 0);
-        timerText = Widget::create<LedDisplayChoice>(pos);
-        timerText->textOffset = Vec(3, 14);
-        timerText->box.size = Vec(35, 22);
-        pos = timerText->box.getBottomLeft();
-        setSeconds(0);
-        addChild(timerText);
+  RecordingDisplay() {
+    box.size = Vec(35, 44);
+    Vec pos = Vec(0, 0);
+    timerText = Widget::create<LedDisplayChoice>(pos);
+    timerText->textOffset = Vec(3, 14);
+    timerText->box.size = Vec(35, 22);
+    pos = timerText->box.getBottomLeft();
+    setSeconds(0);
+    addChild(timerText);
 
-        separator = Widget::create<LedDisplaySeparator>(pos);
-        separator->box.size.x = box.size.x;
-        addChild(separator);
+    separator = Widget::create<LedDisplaySeparator>(pos);
+    separator->box.size.x = box.size.x;
+    addChild(separator);
 
-        formatChoice = Widget::create<LedDisplayChoice>(pos);
-        formatChoice->textOffset = Vec(3, 14);
-        formatChoice->box.size = Vec(35, 22);
-        pos = formatChoice->box.getBottomLeft();
-        addChild(formatChoice);
+    formatChoice = Widget::create<LedDisplayChoice>(pos);
+    formatChoice->textOffset = Vec(3, 14);
+    formatChoice->box.size = Vec(35, 22);
+    pos = formatChoice->box.getBottomLeft();
+    addChild(formatChoice);
+  }
+
+  void setSeconds(float seconds) {
+    float frac_second = seconds - int(seconds);
+    if (seconds > 60 * 60) {
+      seconds /= 60;
     }
 
-    void setSeconds(float seconds) {
-        float frac_second = seconds - int(seconds);
-        if (seconds > 60 * 60) {
-            seconds /= 60;
-        }
+    int a = int(seconds) / 60, b = int(seconds) % 60;
 
-        int a = int(seconds) / 60, b = int(seconds) % 60;
-
-        // Blink the : every second
-        if (frac_second < 0.5 or not recording) {
-            sprintf(msg, "%02d:%02d", a, b);
-        } else {
-            sprintf(msg, "%02d %02d", a, b);
-        }
-
-        timerText->text = msg;
+    // Blink the : every second
+    if (frac_second < 0.5 or not recording) {
+      sprintf(msg, "%02d:%02d", a, b);
+    } else {
+      sprintf(msg, "%02d %02d", a, b);
     }
 
-    void setDisplay(SampleFmt format) {
-        switch(format) {
-        case SampleFmt::PCM_U8:
-            formatChoice->text = "8 USI";
-            break;
-        case SampleFmt::PCM_S16:
-            formatChoice->text = "16 SI";
-            break;
-        case SampleFmt::FLOAT_32:
-            formatChoice->text = "32 FL";
-            break;
-        default:
-            formatChoice->text = "ERROR";
-            break;
-        }
-    }
+    timerText->text = msg;
+  }
 
-    void onMouseDown(EventMouseDown &e) override {
-        Menu *menu = gScene->createMenu();
-        menu->addChild(construct<MenuLabel>(&MenuLabel::text, "Format"));
-        if (recorder->recording) {
-            menu->addChild(MenuItem::create("Can't change formats while recording!"));
-        } else {
-            menu->addChild(new FormatItem(SampleFmt::PCM_U8, recorder));
-            menu->addChild(new FormatItem(SampleFmt::PCM_S16, recorder));
-            menu->addChild(new FormatItem(SampleFmt::FLOAT_32, recorder));
-        }
+  void setDisplay(SampleFmt format) {
+    switch (format) {
+    case SampleFmt::PCM_U8:
+      formatChoice->text = "8 USI";
+      break;
+    case SampleFmt::PCM_S16:
+      formatChoice->text = "16 SI";
+      break;
+    case SampleFmt::FLOAT_32:
+      formatChoice->text = "32 FL";
+      break;
+    default:
+      formatChoice->text = "ERROR";
+      break;
     }
+  }
+
+  void onMouseDown(EventMouseDown &e) override {
+    Menu *menu = gScene->createMenu();
+    menu->addChild(construct<MenuLabel>(&MenuLabel::text, "Format"));
+    if (recorder->recording) {
+      menu->addChild(MenuItem::create("Can't change formats while recording!"));
+    } else {
+      menu->addChild(new FormatItem(SampleFmt::PCM_U8, recorder));
+      menu->addChild(new FormatItem(SampleFmt::PCM_S16, recorder));
+      menu->addChild(new FormatItem(SampleFmt::FLOAT_32, recorder));
+    }
+  }
 };
 
 struct RecorderWidget : ModuleWidget {
-    Recorder *recorder;
-    RecordingDisplay *display;
-    RecordButton *button;
-    RecorderWidget(Recorder *module);
-    void step() override;
-    void fromJson(json_t *rootJ) override;
+  Recorder *recorder;
+  RecordingDisplay *display;
+  RecordButton *button;
+  RecorderWidget(Recorder *module);
+  void step() override;
+  void fromJson(json_t *rootJ) override;
 };
 
 RecorderWidget::RecorderWidget(Recorder *module) : ModuleWidget(module) {
-    setPanel(SVG::load(assetPlugin(plugin, "res/Recorder.svg")));
-    recorder = module;
+  setPanel(SVG::load(assetPlugin(plugin, "res/Recorder.svg")));
+  recorder = module;
 
-    // Mounting Screws
-    addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
-    addChild(Widget::create<ScrewSilver>(Vec(15, 365)));
+  // Mounting Screws
+  addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
+  addChild(Widget::create<ScrewSilver>(Vec(15, 365)));
 
-    // Recording ports
-    addInput(Port::create<PJ301MPort>(Vec(10, 50), Port::INPUT, module, Recorder::LEFT_INPUT));
-    addInput(Port::create<PJ301MPort>(Vec(10, 90), Port::INPUT, module, Recorder::RIGHT_INPUT));
+  // Recording ports
+  addInput(Port::create<PJ301MPort>(Vec(10, 50), Port::INPUT, module,
+                                    Recorder::LEFT_INPUT));
+  addInput(Port::create<PJ301MPort>(Vec(10, 90), Port::INPUT, module,
+                                    Recorder::RIGHT_INPUT));
 
-    display = Widget::create<RecordingDisplay>(Vec(5, 140));
-    display->recorder = module;
-    addChild(display);
-    button = ParamWidget::create<RecordButton>(Vec(7.5, 200), module, Recorder::RECORD_BUTTON, 0.0f, 1.0f, 0.0f);
-    addParam(button);
-    addParam(ParamWidget::create<CKSS>(Vec(15, 260), module, Recorder::MONO_STEREO, 0.0f, 1.0f, 0.0f));
+  display = Widget::create<RecordingDisplay>(Vec(5, 140));
+  display->recorder = module;
+  addChild(display);
+  button = ParamWidget::create<RecordButton>(
+      Vec(7.5, 200), module, Recorder::RECORD_BUTTON, 0.0f, 1.0f, 0.0f);
+  addParam(button);
+  addParam(ParamWidget::create<CKSS>(Vec(15, 260), module,
+                                     Recorder::MONO_STEREO, 0.0f, 1.0f, 0.0f));
 }
 
 void RecorderWidget::fromJson(json_t *rootJ) {
-    ModuleWidget::fromJson(rootJ);
-    button->setValue(0.0); // Make sure the Recorder isn't recording initially.
+  ModuleWidget::fromJson(rootJ);
+  button->setValue(0.0); // Make sure the Recorder isn't recording initially.
 }
 
 void RecorderWidget::step() {
-    display->recording = recorder->recording;
-    display->setSeconds(recorder->getSeconds());
-    display->setDisplay(recorder->format);
+  display->recording = recorder->recording;
+  display->setSeconds(recorder->getSeconds());
+  display->setDisplay(recorder->format);
 }
 
-Model *modelRecorder = Model::create<Recorder, RecorderWidget>("MicroTools", "Recorder", "Recorder", RECORDING_TAG);
+Model *modelRecorder = Model::create<Recorder, RecorderWidget>(
+    "MicroTools", "Recorder", "Recorder", RECORDING_TAG);

--- a/src/wavwriter.cpp
+++ b/src/wavwriter.cpp
@@ -7,37 +7,38 @@
 
 #define SIZE_OF_HEADER 36
 
-void write(FILE* f, int size, int32_t arg)
-{
+void write(FILE *f, int size, int32_t arg) {
   uint8_t x;
   int16_t y;
   int32_t z;
 
   switch (size) {
   case 1:
-    x = (uint8_t) arg;
+    x = (uint8_t)arg;
     fwrite(&x, size, 1, f);
     break;
   case 2:
-    y = (int16_t) arg;
+    y = (int16_t)arg;
     fwrite(&y, size, 1, f);
     break;
   case 4:
-    z = (int32_t) arg;
+    z = (int32_t)arg;
     fwrite(&z, size, 1, f);
     break;
   }
 }
 
-const char* toString(SampleFmt format) {
-    switch(format) {
-        case SampleFmt::PCM_U8:
-            return "8 bit unsigned";
-        case SampleFmt::PCM_S16:
-            return "16 bit signed";
-        case SampleFmt::FLOAT_32:
-            return "32 bit float";
-    }
+const char *toString(SampleFmt format) {
+  switch (format) {
+  case SampleFmt::PCM_U8:
+    return "8 bit unsigned";
+  case SampleFmt::PCM_S16:
+    return "16 bit signed";
+  case SampleFmt::FLOAT_32:
+    return "32 bit float";
+  default:
+    assert(not"an expected format");
+  }
 }
 
 void writewav(uint8_t *data, SampleFmt format, int num_channels, int samples,
@@ -46,39 +47,40 @@ void writewav(uint8_t *data, SampleFmt format, int num_channels, int samples,
   // before every `0a = \n` (CLRF vs LF line ending nonsense).
   FILE *f = fopen(filename, "wb");
 
-  int sample_bytes, wav_format;
+  int sample_bytes = 0;
+  int wav_format = 0;
   switch (format) {
   case PCM_U8:
-      sample_bytes = 1, wav_format = 1;
-      break;
+    sample_bytes = 1, wav_format = 1;
+    break;
   case PCM_S16:
-      sample_bytes = 2, wav_format = 1;
-      break;
+    sample_bytes = 2, wav_format = 1;
+    break;
   case FLOAT_32:
-      sample_bytes = 4, wav_format = 3;
-      break;
+    sample_bytes = 4, wav_format = 3;
+    break;
   default:
-      assert(not "an expected format");
+    assert(not"an expected format");
   }
   int total_bytes = num_channels * sample_bytes * samples;
   int block_align = num_channels * sample_bytes;
 
   /* header*/
-  fputs("RIFF", f);                              /* main chunk       */
-  write(f, 4, SIZE_OF_HEADER + total_bytes);     /* chunk size       */
-  fputs("WAVE", f);                              /* file format      */
-  fputs("fmt ", f);                              /* format chunk     */
-  write(f, 4, 16);                               /* size of subchunk */
-  write(f, 2, wav_format);                       /* format           */
-  write(f, 2, num_channels);                     /* # of channels    */
-  write(f, 4, sample_rate);                      /* sample rate      */
-  write(f, 4, block_align * sample_rate);        /* byte rate        */
-  write(f, 2, block_align);                      /* block align      */
-  write(f, 2, 8 * sample_bytes);                 /* bits per sample  */
-  fputs("data", f);                              /* data chunk       */
+  fputs("RIFF", f);                          /* main chunk       */
+  write(f, 4, SIZE_OF_HEADER + total_bytes); /* chunk size       */
+  fputs("WAVE", f);                          /* file format      */
+  fputs("fmt ", f);                          /* format chunk     */
+  write(f, 4, 16);                           /* size of subchunk */
+  write(f, 2, wav_format);                   /* format           */
+  write(f, 2, num_channels);                 /* # of channels    */
+  write(f, 4, sample_rate);                  /* sample rate      */
+  write(f, 4, block_align * sample_rate);    /* byte rate        */
+  write(f, 2, block_align);                  /* block align      */
+  write(f, 2, 8 * sample_bytes);             /* bits per sample  */
+  fputs("data", f);                          /* data chunk       */
 
   /* body */
-  fwrite(data, 1, total_bytes, f);               /* actual audio     */
+  fwrite(data, 1, total_bytes, f); /* actual audio     */
 
   fclose(f);
 }

--- a/src/wavwriter.cpp
+++ b/src/wavwriter.cpp
@@ -40,8 +40,11 @@ const char* toString(SampleFmt format) {
     }
 }
 
-void writewav(uint8_t *data, SampleFmt format, int num_channels, int samples, int sample_rate, const char* filename) {
-  FILE* f = fopen(filename, "w");
+void writewav(uint8_t *data, SampleFmt format, int num_channels, int samples,
+              int sample_rate, const char *filename) {
+  // Note: This is "write bytes" as to avoid Windows from sticking `0d = \r`
+  // before every `0a = \n` (CLRF vs LF line ending nonsense).
+  FILE *f = fopen(filename, "wb");
 
   int sample_bytes, wav_format;
   switch (format) {

--- a/src/wavwriter.hpp
+++ b/src/wavwriter.hpp
@@ -6,13 +6,14 @@
 #include <cstdint>
 
 enum SampleFmt {
-    PCM_U8,
-    PCM_S16,
-    FLOAT_32,
+  PCM_U8,
+  PCM_S16,
+  FLOAT_32,
 };
 
-const char* toString(SampleFmt format);
+const char *toString(SampleFmt format);
 
-void writewav(uint8_t *data, SampleFmt format, int num_channels, int samples, int sample_rate, const char* filename);
+void writewav(uint8_t *data, SampleFmt format, int num_channels, int samples,
+              int sample_rate, const char *filename);
 
 #endif


### PR DESCRIPTION
It turns out that Windows will automatically append
`0d = \r` bytes after every `0a = \n` when writing to a file
in "write" (w) mode since it uses CRLF. This ends up corrupting
the WAV file due to the added `0d` bytes. To fix this we instead
open the file in "write bytes" (wb) mode.
